### PR TITLE
Keep playlist deletions consistent

### DIFF
--- a/static/js/playlist-dnd.js
+++ b/static/js/playlist-dnd.js
@@ -68,6 +68,16 @@
     return li;
   }
 
+  function updateNewSongsInput(listEl, inputEl) {
+    if (!inputEl) return;
+    const ids = $all(".dnd-item", listEl)
+      .filter(li => li.dataset.kind === "new")
+      .filter(li => !li.classList.contains("is-deleted"))
+      .map(li => li.dataset.songId)
+      .filter(Boolean);
+    inputEl.value = joinPipe(ids);
+  }
+
   function initPlaylistDnd(opts) {
     const {
       sourceList,            // #add-songs
@@ -79,6 +89,15 @@
 
     if (!sourceList || !targetList || !formEl || !inputOrderedIds || !inputNewSongs) return;
 
+    // track whether the drag was initiated from the handle so we do not start
+    // dragging when the user simply clicks the row to focus / select text.
+    let activeHandleItem = null;
+    targetList.addEventListener("pointerdown", (e) => {
+      const handle = e.target.closest(".dnd-handle");
+      activeHandleItem = handle ? handle.closest(".dnd-item") : null;
+    });
+    window.addEventListener("pointerup", () => { activeHandleItem = null; });
+
     // Delete (×)
     targetList.addEventListener("click", (e) => {
       const btn = e.target.closest(".dnd-x");
@@ -86,29 +105,30 @@
       const li = btn.closest(".dnd-item");
       if (!li) return;
 
+      const shouldDelete = !li.classList.contains("is-deleted");
+      if (shouldDelete) {
+        li.classList.add("is-deleted", "strike");
+      } else {
+        li.classList.remove("is-deleted", "strike");
+      }
+
       if (li.dataset.kind === "new") {
-        const sid = li.dataset.songId;
-        const ids = splitPipe(inputNewSongs.value);
-        const idx = ids.indexOf(String(sid));
-        if (idx >= 0) ids.splice(idx, 1);
-        inputNewSongs.value = joinPipe(ids);
-        li.remove();
+        updateNewSongsInput(targetList, inputNewSongs);
       } else {
         const asid = li.getAttribute("data-asid");
         if (!asid) return;
         const delHiddenName = `box_delete_song_${asid}`;
         const existingHidden = formEl.querySelector(`input[name="${delHiddenName}"]`);
-        if (li.classList.toggle("is-deleted")) {
+        if (shouldDelete) {
           if (!existingHidden) formEl.appendChild(mkHiddenDelete(asid));
-          li.classList.add("strike");
         } else {
           existingHidden?.remove();
-          li.classList.remove("strike");
         }
       }
 
       inputOrderedIds.value = serializeExistingOrder(targetList);
       renumberAll(targetList);
+      updateNewSongsInput(targetList, inputNewSongs);
     });
 
     // Drag & drop (all items participate)
@@ -125,11 +145,19 @@
 
     // Limit drag start to the handle for better UX (optional: remove the guard if you want full-row drag)
     targetList.addEventListener("dragstart", (e) => {
-      const handle = e.target.closest(".dnd-handle");
-      if (!handle) return;
-      const li = handle.closest(".dnd-item");
+      const li = e.target.closest(".dnd-item");
       if (!li) return;
+      if (activeHandleItem && activeHandleItem !== li) {
+        activeHandleItem = null;
+        e.preventDefault();
+        return;
+      }
+      if (!activeHandleItem) {
+        e.preventDefault();
+        return;
+      }
       draggingEl = li;
+      activeHandleItem = null;
       li.classList.add("dragging");
       e.dataTransfer.effectAllowed = "move";
       e.dataTransfer.setData("text/plain", li.dataset.kind === "new"
@@ -143,6 +171,7 @@
       draggingEl = null;
       inputOrderedIds.value = serializeExistingOrder(targetList);
       renumberAll(targetList);
+      updateNewSongsInput(targetList, inputNewSongs);
     });
 
     function getAfter(container, y) {
@@ -179,6 +208,7 @@
       const after = getAfter(targetList, y);
       if (after == null) targetList.appendChild(draggingEl);
       else targetList.insertBefore(draggingEl, after);
+      updateNewSongsInput(targetList, inputNewSongs);
     });
 
     // Add: double-click source or drag from source
@@ -205,14 +235,17 @@
 
     function stageNew(songId, title) {
       const ids = splitPipe(inputNewSongs.value);
-      ids.push(String(songId));
+      const sid = String(songId);
+      if (!ids.includes(sid)) ids.push(sid);
       inputNewSongs.value = joinPipe(ids);
 
       const li = createNewDraggableItem(songId, title);
+      li.tabIndex = 0;
       targetList.appendChild(li);
 
       inputOrderedIds.value = serializeExistingOrder(targetList);
       renumberAll(targetList);
+      updateNewSongsInput(targetList, inputNewSongs);
     }
 
     // Keyboard fallback
@@ -230,6 +263,7 @@
       }
       inputOrderedIds.value = serializeExistingOrder(targetList);
       renumberAll(targetList);
+      updateNewSongsInput(targetList, inputNewSongs);
     });
 
     // Focusable items
@@ -238,6 +272,7 @@
     // Initial state
     inputOrderedIds.value = serializeExistingOrder(targetList);
     renumberAll(targetList);
+    updateNewSongsInput(targetList, inputNewSongs);
   }
 
   window.initPlaylistDnd = initPlaylistDnd;


### PR DESCRIPTION
## Summary
- strike playlist rows instead of removing them so new and existing songs share the same delete affordance
- recalculate the staged new song list whenever items are toggled or reordered to keep the hidden input in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690ca9c545d88326a389f82c54d2bec5