### PR TITLE
Add tabs to animation playlist song picker

### DIFF
--- a/app_animation/templates/app_animation/animation_playlist.html
+++ b/app_animation/templates/app_animation/animation_playlist.html
@@ -11,8 +11,39 @@
 <hr>
 {% endblock bloc1 %}
 {% block bloc2 %}
+<div id="song-tabs" class="flex gap-2 mb-3" role="tablist" aria-label="{% trans 'Song lists' %}">
+  <button id="tab-search" type="button" class="btn btn-outline-primary" data-tab-target="search" role="tab" aria-selected="true">
+    {% trans "Recherche" %}
+  </button>
+  <button id="tab-favorites" type="button" class="btn btn-outline-primary" data-tab-target="favorites" role="tab" aria-selected="false">
+    {% trans "Favoris" %} ⭐
+  </button>
+  <button id="tab-all" type="button" class="btn btn-outline-primary" data-tab-target="all" role="tab" aria-selected="false">
+    {% trans "Tous les chants" %}
+  </button>
+</div>
 <nav id="add-songs" class="overflow-y-auto" style="height:75vh;">
-  <ul>
+  <ul class="tab-panel" data-tab="search" role="tabpanel" aria-labelledby="tab-search">
+  {% for song in all_songs %}
+    <li class="dnd-item" data-asid="{{ song.song_id }}" draggable="true">
+      <span class="dnd-handle-num">
+        <span class="dnd-handle" aria-hidden="true">⠿</span>
+      </span>
+      <span class="dnd-title">{{ song.full_title }}</span>
+    </li>
+  {% endfor %}
+  </ul>
+  <ul class="tab-panel" data-tab="favorites" role="tabpanel" aria-labelledby="tab-favorites" hidden>
+  {% for song in all_songs %}
+    <li class="dnd-item" data-asid="{{ song.song_id }}" draggable="true">
+      <span class="dnd-handle-num">
+        <span class="dnd-handle" aria-hidden="true">⠿</span>
+      </span>
+      <span class="dnd-title">{{ song.full_title }}</span>
+    </li>
+  {% endfor %}
+  </ul>
+  <ul class="tab-panel" data-tab="all" role="tabpanel" aria-labelledby="tab-all" hidden>
   {% for song in all_songs %}
     <li class="dnd-item" data-asid="{{ song.song_id }}" draggable="true">
       <span class="dnd-handle-num">
@@ -23,6 +54,38 @@
   {% endfor %}
   </ul>
 </nav>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const tabsContainer = document.getElementById('song-tabs');
+    const nav = document.getElementById('add-songs');
+    if (!tabsContainer || !nav) return;
+    const panels = Array.from(nav.querySelectorAll('[data-tab]'));
+    const buttons = Array.from(tabsContainer.querySelectorAll('[data-tab-target]'));
+
+    function activateTab(name) {
+      panels.forEach((panel) => {
+        const isActive = panel.dataset.tab === name;
+        panel.toggleAttribute('hidden', !isActive);
+        panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+      buttons.forEach((btn) => {
+        const isActive = btn.dataset.tabTarget === name;
+        btn.classList.toggle('btn-primary', isActive);
+        btn.classList.toggle('btn-outline-primary', !isActive);
+        btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+    }
+
+    tabsContainer.addEventListener('click', (event) => {
+      const btn = event.target.closest('[data-tab-target]');
+      if (!btn) return;
+      activateTab(btn.dataset.tabTarget);
+    });
+
+    const defaultTab = buttons[0]?.dataset.tabTarget || panels[0]?.dataset.tab;
+    if (defaultTab) activateTab(defaultTab);
+  });
+</script>
 {% endblock bloc2 %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add tab buttons above the song picker for search, favorites, and all songs
- prepare separate tab panels that currently show the same list of songs
- add small script to toggle the visible tab and update styling

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e18df509c8326b4564b515db62f54)