### PR TITLE
Animate strikethrough hover effect

### DIFF
--- a/static/css/normal.css
+++ b/static/css/normal.css
@@ -83,11 +83,28 @@ hr {
     background-color: rgb(206, 197, 194);
 }
 
-.L_LINE_THROUGH:hover {
-    text-decoration: line-through !important;
-    text-decoration-color: #8b1e1e;
-    text-decoration-thickness: 2px;
-    text-decoration-skip-ink: none;
+.L_LINE_THROUGH {
+    position: relative;
+    display: inline-block;
+    text-decoration: none !important;
+}
+
+.L_LINE_THROUGH::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 100%;
+    height: 2px;
+    background-color: #8b1e1e;
+    transform: translate(-50%, -50%) scaleX(0);
+    transform-origin: center;
+    transition: transform 1s ease;
+    pointer-events: none;
+}
+
+.L_LINE_THROUGH:hover::after {
+    transform: translate(-50%, -50%) scaleX(1);
 }
 
 .L_BUTTON_LIKE_A_LINK {


### PR DESCRIPTION
## Summary
- replace the direct text-decoration hover rule for `.L_LINE_THROUGH` with a pseudo-element animation
- animate the strikethrough line from the center outward over one second when hovering

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691495f1096883268757059064bf17a0)